### PR TITLE
Add amd_butler_params_one_line setting

### DIFF
--- a/AmdButler.sublime-settings
+++ b/AmdButler.sublime-settings
@@ -1,3 +1,4 @@
 {
-    "amd_butler_packages_base_path": ""
+    "amd_butler_packages_base_path": "",
+    "amd_butler_params_one_line": false
 }

--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ Clone the [source code](https://github.com/agrc/AmdButler) for this plugin to yo
 The name of the folder containing your AMD packages. This folder is crawled and all files are made available as imports for the "Add AMD Import" command.
 
 This settings can be set either at the package level (Preferences -> Package Settings -> AmdButler) or in the project file settings. No manual editing of settings files is needed. The user is prompted for the value if it's not present in either the project or package settings the first time that the "Add AMD Import" command is run.
+
+#### `amd_butler_params_one_line`
+If `true`, the params will be rewritten to one line per section (instead of the default (`false`), one line per parameter).

--- a/amdbutler.py
+++ b/amdbutler.py
@@ -6,6 +6,7 @@ from . import crawler
 from . import zipper
 
 PATH_SETTING_NAME = 'amd_butler_packages_base_path'
+PARAMS_ONE_LINE_SETTING_NAME = 'amd_butler_params_one_line'
 SETTINGS_FILE_NAME = 'AmdButler.sublime-settings'
 
 
@@ -27,9 +28,12 @@ def _update_with_pairs(view, edit, pairs):
     imports_span = buffer_parser.get_imports_span(_all_text(view))
     params_span = buffer_parser.get_params_span(_all_text(view))
 
+    settings = sublime.load_settings(SETTINGS_FILE_NAME)
+    paramsOneLineSetting = settings.get(PARAMS_ONE_LINE_SETTING_NAME)
+
     # replace params - do these first since they won't affect the
     # imports region
-    params_txt = zipper.generate_params_txt(pairs, '\t')
+    params_txt = zipper.generate_params_txt(pairs, '\t', paramsOneLineSetting)
     view.replace(edit, sublime.Region(*params_span), params_txt)
 
     # replace imports

--- a/amdbutler.sublime-project
+++ b/amdbutler.sublime-project
@@ -20,6 +20,7 @@
 	],
 	"settings":
 	{
-		"amd_butler_packages_base_path": "crawlTest"
+		"amd_butler_packages_base_path": "crawlTest",
+		"amd_butler_params_one_line": false
 	}
 }

--- a/zipper.py
+++ b/zipper.py
@@ -47,9 +47,23 @@ def generate_imports_txt(pairs, indent):
     return txt
 
 
-def generate_params_txt(pairs, indent):
+def generate_params_txt(pairs, indent, oneLine):
     package = None
-    txt = ''
+
+    # normal settings:
+    initialTxt = ''
+    endLineTxt = ',\n'
+    afterItemTxt = ','
+    everyIterTxt = '\n    '
+
+    # config setting of params on one line:
+    if oneLine == True:
+        initialTxt = '\n    '
+        endLineTxt = ',\n    '
+        afterItemTxt = ', '
+        everyIterTxt = ''
+
+    txt = initialTxt
 
     for p in pairs:
         new_package = p[0].split('/')[0]
@@ -57,12 +71,12 @@ def generate_params_txt(pairs, indent):
             if package is None:
                 package = new_package
             elif package != new_package:
-                txt += ',\n'
+                txt += endLineTxt
                 package = new_package
             else:
-                txt += ','
+                txt += afterItemTxt
 
-            txt += '\n    ' + p[1]
+            txt += everyIterTxt + p[1]
 
     txt += '\n'
 


### PR DESCRIPTION
Adds the new parameter as an option, and correctly formats the parameters section to the more compact version if setting is true. The setting is false by default.

Tests not included currently.

resolves #19 
